### PR TITLE
Feature/connectv2

### DIFF
--- a/exports.js
+++ b/exports.js
@@ -1,5 +1,5 @@
 var path = require('path');
-var stylesDir = __dirname + 'src/styles'
+var stylesDir = __dirname + '/src/styles'
 
 function includePaths() {
   return require('node-neat').includePaths.concat(stylesDir);

--- a/exports.js
+++ b/exports.js
@@ -1,12 +1,11 @@
-var path = require('path');
-var stylesDir = __dirname + '/src/styles'
+const stylesDir = __dirname + '/src/styles'
 
 function includePaths() {
-  return require('node-neat').includePaths.concat(stylesDir);
+  return require('node-neat').includePaths.concat(stylesDir)
 }
 
 module.exports = {
 
   includePaths: includePaths()
 
-};
+}

--- a/exports.js
+++ b/exports.js
@@ -1,0 +1,12 @@
+var path = require('path');
+var stylesDir = __dirname + 'src/styles'
+
+function includePaths() {
+  return require('node-neat').includePaths.concat(stylesDir);
+}
+
+module.exports = {
+
+  includePaths: includePaths()
+
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "tc-ui",
   "version": "0.0.0",
+  "main": "exports.js",
   "description": "Topcoder UI components and style guide",
   "devDependencies": {
     "appirio-tech-webpack-config": "0.x.x",
@@ -35,6 +36,7 @@
     "react-router": "^2.0.0-rc6",
     "redux": "^3.3.1",
     "react-redux": "^4.2.1",
-    "react-select": "^0.9.1"
+    "react-select": "^0.9.1",
+    "node-neat": "~1.7.1-beta1"
   }
 }

--- a/src/styles/_buttons.scss
+++ b/src/styles/_buttons.scss
@@ -6,88 +6,107 @@
 // Buttons
 
 // Links
+a.tc-link,
 .tc-link,
+a.tc-link:active,
 .tc-link:active,
+a.tc-link:visited,
 .tc-link:visited {
   cursor: pointer;
 }
 
+a.tc-link:hover,
 .tc-link:hover {
   color: $tc-dark-blue;
   text-decoration: none;
 }
 
+a.tc-btn,
 .tc-btn {
   @include proxima-nova-medium;
   border-radius: 2px;
 }
 
+a.tc-btn:focus,
 .tc-btn:focus {
   outline: none;
 }
 
+a.tc-btn-lg,
 .tc-btn-lg {
   height: 50px;
   padding: 10px 30px;
 }
 
+a.tc-btn-md,
 .tc-btn-md {
   height: 40px;
   padding: 10px 25px;
 }
 
+a.tc-btn-sm,
 .tc-btn-sm {
   height: 30px;
   padding: 5px 15px;
 }
 
+a.tc-btn-xs,
 .tc-btn-xs {
   height: 20px;
   padding: 3px 10px;
 }
 
+a.tc-btn-pressed,
 .tc-btn-pressed {
   box-shadow: 0px 1px 3px 0px $tc-gray-80;
 }
 
+a.tc-btn-primary,
 .tc-btn-primary {
   background-color: $tc-dark-blue-90;
   color: $tc-gray-neutral-light;
   border: 1px solid $tc-dark-blue;
 }
 
+a.tc-btn-primary:hover,
 .tc-btn-primary:hover {
   color: $tc-gray-neutral-light;
   @include background(linear-gradient($tc-dark-blue-90, $tc-dark-blue) left repeat);
 }
 
+a.tc-btn-primary:active,
 .tc-btn-primary:active {
   color: $tc-gray-neutral-light;
   @include background(linear-gradient($tc-dark-blue, $tc-dark-blue-90) left repeat);
 }
 
+a.tc-btn-secondary,
 .tc-btn-secondary {
   background-color: $tc-gray-40;
   color: $tc-gray-neutral-light;
   border: 1px solid $tc-gray-50;
 }
 
+a.tc-btn-secondary:hover,
 .tc-btn-secondary:hover {
   color: $tc-gray-neutral-light;
   @include background(linear-gradient($tc-gray-40, $tc-gray-50) left repeat);
 }
 
+a.tc-btn-secondary:active,
 .tc-btn-secondary:active {
   color: $tc-gray-neutral-light;
   @include background(linear-gradient($tc-gray-50, $tc-gray-40) left repeat);
 }
 
+a.tc-btn-default,
 .tc-btn-default {
   background-color: white;
   color: $tc-gray-70;
   border: 1px solid $tc-gray-50;
 }
 
+a.tc-btn-warning,
 .tc-btn-warning {
   background-color: $tc-red-70;
   color: $tc-gray-neutral-light;

--- a/src/styles/_buttons.scss
+++ b/src/styles/_buttons.scss
@@ -16,3 +16,80 @@
   color: $tc-dark-blue;
   text-decoration: none;
 }
+
+.tc-btn {
+  @include proxima-nova-medium;
+  border-radius: 2px;
+}
+
+.tc-btn:focus {
+  outline: none;
+}
+
+.tc-btn-lg {
+  height: 50px;
+  padding: 10px 30px;
+}
+
+.tc-btn-md {
+  height: 40px;
+  padding: 10px 25px;
+}
+
+.tc-btn-sm {
+  height: 30px;
+  padding: 5px 15px;
+}
+
+.tc-btn-xs {
+  height: 20px;
+  padding: 3px 10px;
+}
+
+.tc-btn-pressed {
+  box-shadow: 0px 1px 3px 0px $tc-gray-80;
+}
+
+.tc-btn-primary {
+  background-color: $tc-dark-blue-90;
+  color: $tc-gray-neutral-light;
+  border: 1px solid $tc-dark-blue;
+}
+
+.tc-btn-primary:hover {
+  color: $tc-gray-neutral-light;
+  @include background(linear-gradient($tc-dark-blue-90, $tc-dark-blue) left repeat);
+}
+
+.tc-btn-primary:active {
+  color: $tc-gray-neutral-light;
+  @include background(linear-gradient($tc-dark-blue, $tc-dark-blue-90) left repeat);
+}
+
+.tc-btn-secondary {
+  background-color: $tc-gray-40;
+  color: $tc-gray-neutral-light;
+  border: 1px solid $tc-gray-50;
+}
+
+.tc-btn-secondary:hover {
+  color: $tc-gray-neutral-light;
+  @include background(linear-gradient($tc-gray-40, $tc-gray-50) left repeat);
+}
+
+.tc-btn-secondary:active {
+  color: $tc-gray-neutral-light;
+  @include background(linear-gradient($tc-gray-50, $tc-gray-40) left repeat);
+}
+
+.tc-btn-default {
+  background-color: white;
+  color: $tc-gray-70;
+  border: 1px solid $tc-gray-50;
+}
+
+.tc-btn-warning {
+  background-color: $tc-red-70;
+  color: $tc-gray-neutral-light;
+  border: 1px solid $tc-red;
+}

--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -160,3 +160,9 @@
   &.level-4 { background-color: $tc-level-4; }
   &.level-5 { background-color: $tc-level-5; }
 }
+
+@mixin ellipsis {
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}

--- a/src/styles/_tc-includes.scss
+++ b/src/styles/_tc-includes.scss
@@ -1,2 +1,3 @@
+@import 'bourbon';
 @import 'mixins';
 @import 'variables';

--- a/src/styles/_tc-styles.scss
+++ b/src/styles/_tc-styles.scss
@@ -27,3 +27,56 @@ a {
     color: inherit;
   }
 }
+
+.flex {
+  display: flex;
+
+  &.column {
+    flex-direction: column;
+  }
+
+  &.center {
+    justify-content: center;
+  }
+
+  &.end {
+    justify-content: flex-end;
+  }
+
+  &.space-between {
+    justify-content: space-between;
+  }
+
+  &.space-around {
+    justify-content: space-around;
+  }
+
+  &.middle {
+    align-items : center;
+  }
+
+  &.stretch {
+    align-items: stretch;
+  }
+
+  &.bottom {
+    align-items: flex-end;
+  }
+
+  &.wrap {
+    flex-wrap: wrap;
+  }
+}
+
+.flex-grow {
+  flex-grow: 1;
+}
+
+.flex-one {
+  flex: 1;
+}
+
+.flex-shrink {
+  flex-shrink: 1;
+  flex-basis: 100px;
+}

--- a/src/styles/_tc-styles.scss
+++ b/src/styles/_tc-styles.scss
@@ -29,54 +29,54 @@ a {
 }
 
 .flex {
-  display: flex;
+  @include display(flex);
 
   &.column {
-    flex-direction: column;
+    @include flex-direction(column);
   }
 
   &.center {
-    justify-content: center;
+    @include justify-content(center);
   }
 
   &.end {
-    justify-content: flex-end;
+    @include justify-content(flex-end);
   }
 
   &.space-between {
-    justify-content: space-between;
+    @include justify-content(space-between);
   }
 
   &.space-around {
-    justify-content: space-around;
+    @include justify-content(space-around);
   }
 
   &.middle {
-    align-items : center;
+    @include align-items(center);
   }
 
   &.stretch {
-    align-items: stretch;
+    @include align-items(stretch);
   }
 
   &.bottom {
-    align-items: flex-end;
+    @include align-items(flex-end);
   }
 
   &.wrap {
-    flex-wrap: wrap;
+    @include flex-wrap(wrap);
   }
 }
 
 .flex-grow {
-  flex-grow: 1;
+  @include flex-grow(1);
 }
 
 .flex-one {
-  flex: 1;
+  @include flex(1);
 }
 
 .flex-shrink {
-  flex-shrink: 1;
-  flex-basis: 100px;
+  @include flex-shrink(1);
+  @include flex-basis(100px);
 }

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -95,3 +95,9 @@ $tc-heading-large      : 28px;
 $tc-heading            : 20px;
 $tc-heading-small      : 16px;
 $tc-heading-extra-small: 14px;
+
+// breakpoints
+$screen-lg : 1376px;
+$screen-md : 768px;
+$screen-sm : 640px;
+$screen-xs : 320px;


### PR DESCRIPTION
Refactor and cleanup the TC UI Kit / Connect 2

* Better organization of files, mirror structure of Bootstrap 4;
* Remove dependency of Bourbon - this is a pretty big dependency/library, and I think we should avoid making the TC UI Kit dependent on third party libraries at this point. The goal is to allow the community to download the TC UI "Styles" folder and use it locally to develop static HTML/SCSS code, as well as translate this into a final React components;
* Fixed the style of the "buttons";
* Added forms - there are some changes pending there;
* Split Mixins into a import file and sub-directory to make it easy to contain future expansion;
* Started refactoring on the variable names - instead of using "label-large", we now should use "label-lg", "label-md", "label-sm", similarly to the way we use it in buttons. This is to keep the consistent pattern of expressing size through 2 letter code, which is self explanatory;
* Removed Proxima Nova as typeface from our typography
* Numerous small fixes

Should not break things; if we see breaking - let's fix the use of variable names.

**In general - we don't have a good consistent use of variables, calculations, mixins. Let's try to straighten things going forward**
