### PR TITLE
Fix roboto-bold mixin font weight to 700

### DIFF
--- a/src/styles/mixins/_typography.scss
+++ b/src/styles/mixins/_typography.scss
@@ -26,7 +26,7 @@
 
 @mixin roboto-bold {
   font-family: 'Roboto', Helvetica, Arial, sans-serif;
-  font-weight: 600;
+  font-weight: 700;
 }
 
 // Labels


### PR DESCRIPTION
Fix `roboto-bold` mixin font weight from 600 to 700.

For details, please refere to the next issue from `connect-app` https://github.com/appirio-tech/connect-app/issues/2124