### PR TITLE
issue #24 - [Connect] tc-includes shouldn't include any styles only mixins and variables

### DIFF
--- a/src/styles/_tc-styles.scss
+++ b/src/styles/_tc-styles.scss
@@ -2,6 +2,7 @@
 @import 'reset';
 
 // Use to list all modules to include
+@import 'utils';
 @import 'buttons';
 @import 'checkboxes';
 @import 'forms';

--- a/src/styles/_utils.scss
+++ b/src/styles/_utils.scss
@@ -1,0 +1,27 @@
+// Sizes which were moved here from mixins/_utils.scss
+// because they shouldn't be included in _tc-includes.scss
+// NOTE I didn't find any application which uses these classes
+
+.size-xs {
+	height: 20px;
+	line-height: 18px;
+	font-size: 12px;
+}
+
+.size-sm {
+	height: 30px;
+	line-height: 28px;
+	font-size: 13px;
+}
+
+.size-md {
+	height: 40px;
+	line-height: 38px;
+	font-size: 15px;
+}
+
+.size-lg {
+	height: 50px;
+	line-height: 48px;
+	font-size: 20px;
+}

--- a/src/styles/mixins/_utils.scss
+++ b/src/styles/mixins/_utils.scss
@@ -82,27 +82,3 @@
     @content;
   }
 }
-
-.size-xs {
-  height: 20px;
-  line-height: 18px;
-  font-size: 12px;
-}
-
-.size-sm {
-  height: 30px;
-  line-height: 28px;
-  font-size: 13px;
-}
-
-.size-md {
-  height: 40px;
-  line-height: 38px;
-  font-size: 15px;
-}
-
-.size-lg {
-  height: 50px;
-  line-height: 48px;
-  font-size: 20px;
-}


### PR DESCRIPTION
issue #24 - [Connect] tc-includes shouldn't include any styles only mixins and variables

I've moved out styles from utils of `_tc-includes` to utils of `_tc-styles` which supposed to be included only once.

Note, actually I didn't find a place where we used these classes. In particular, I checked that `connect-app` still displayed as before after this change, so I guess nothing should be broken after such change.